### PR TITLE
[WIP]: Adds breaking test for paths

### DIFF
--- a/test/test_helpers.js
+++ b/test/test_helpers.js
@@ -56,17 +56,36 @@ export function compile(string, options) {
   });
 }
 
+export function get(model, path) {
+  var parts  = {},
+      result = {};
+
+  if (typeof path !== 'string') {
+    parts = path[0];
+    result = model[parts];
+  } else {
+    parts = path.split('.');
+    result = model[parts[0]];
+
+    for (var i = 1, l = parts.length; i < l; i++) {
+      result = result[parts[i]];
+    }
+  }
+
+  return result;
+}
+
 export function PathObserver(model, path) {
   var delegate = this;
 
   var stream = new Stream(function(next) {
     addObserver(model, path, function() {
-      var value = delegate.currentValue = model[path];
+      var value = delegate.currentValue = get(model,path);
       next(value);
     });
   });
 
-  this.currentValue = model[path];
+  this.currentValue = get(model, path);
 
   this.subscribe = function(next) {
     var unsubscribe = stream.subscribe.apply(stream, arguments);

--- a/test/tests/basic_test.js
+++ b/test/tests/basic_test.js
@@ -55,20 +55,6 @@ test("Curlies can be updated when the model changes", function() {
   equalHTML(fragment, "<p>goodbye cruel world</p>");
 });
 
-test("Attributes can be updated when the model changes", function() {
-  var template = compile('<a href="{{url}}">hello</a>');
-
-  var model = { url: "http://example.com/hello" },
-      fragment = template(model);
-
-  equalHTML(fragment, '<a href="http://example.com/hello">hello</a>');
-
-  model.url = "http://example.com/goodbye";
-  notify(model, 'url');
-
-  equalHTML(fragment, '<a href="http://example.com/goodbye">hello</a>');
-});
-
 test("Attribute runs can be updated when the model changes", function() {
   var template = compile('<a href="http://{{host}}/{{path}}">hello</a>');
 
@@ -142,3 +128,23 @@ test("Attribute helpers can merge path streams", function() {
 
   equalHTML(fragment, '<a href="http://www.example.com/goodbye">post</a>');
 });
+
+test("Attribute runs can be updated when the model path changes", function() {
+  var template = compile('<a href="http://{{host.url}}/{{path.url}}">hello</a>');
+  debugger
+  var model = {
+          host: { url: "example.com" },
+          path: { name: "hello" }
+      },
+      fragment = template(model);
+
+  equalHTML(fragment, '<a href="http://example.com/hello">hello</a>');
+
+  model.host = "www.example.com";
+  model.path = "goodbye";
+  notify(model, 'host');
+  notify(model, 'path');
+
+  equalHTML(fragment, '<a href="http://www.example.com/goodbye">hello</a>');
+});
+

--- a/test/tests/basic_test.js
+++ b/test/tests/basic_test.js
@@ -130,8 +130,7 @@ test("Attribute helpers can merge path streams", function() {
 });
 
 test("Attribute runs can be updated when the model path changes", function() {
-  var template = compile('<a href="http://{{host.url}}/{{path.url}}">hello</a>');
-  debugger
+  var template = compile('<a href="http://{{host.url}}/{{path.name}}">hello</a>');
   var model = {
           host: { url: "example.com" },
           path: { name: "hello" }
@@ -140,11 +139,11 @@ test("Attribute runs can be updated when the model path changes", function() {
 
   equalHTML(fragment, '<a href="http://example.com/hello">hello</a>');
 
-  model.host = "www.example.com";
-  model.path = "goodbye";
-  notify(model, 'host');
-  notify(model, 'path');
+  model.host.url = "www.example2.com";
+  model.path.name = "goodbye";
+  notify(model, 'host.url');
+  notify(model, 'path.name');
 
-  equalHTML(fragment, '<a href="http://www.example.com/goodbye">hello</a>');
+  equalHTML(fragment, '<a href="http://www.example2.com/goodbye">hello</a>');
 });
 


### PR DESCRIPTION
My assumption is that this example should work:

Given this model:

``` javascript
var model = {
        host: { url: 'example.com' },
        path: { name: 'hello' }
};
```

And this template:

``` htmlbars
<a href="http://{{host.url}}/{{path.name}}/">hello</a>
```

Expected output:

``` html
<a href="http://example.com/hello">hello</a>
```
